### PR TITLE
add Content-Type to object metadata

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -2,6 +2,7 @@ import glob
 import logging
 from typing import List
 
+import mimetypes
 import boto3
 from botocore.exceptions import ClientError
 
@@ -19,15 +20,18 @@ def upload_file(file_name, bucket, object_name=None):
     if object_name is None:
         object_name = file_name
     try:
+        content_type = mimetypes.guess_type(file_name)[0] or 'binary/octet-stream'
         if bucket == config.PUB_S3_BUCKET:
             s3_client.upload_file(file_name, bucket, object_name, ExtraArgs={
                 'GrantRead': 'id=%s' % config.BRAVE_TODAY_CLOUDFRONT_CANONICAL_ID,
-                'GrantFullControl': 'id=%s' % config.BRAVE_TODAY_CANONICAL_ID
+                'GrantFullControl': 'id=%s' % config.BRAVE_TODAY_CANONICAL_ID,
+                'ContentType': content_type
             })
         elif bucket == config.PRIV_S3_BUCKET:
             s3_client.upload_file(file_name, bucket, object_name, ExtraArgs={
                 'GrantRead': 'id=%s' % config.PRIVATE_CDN_CANONICAL_ID,
-                'GrantFullControl': 'id=%s' % config.PRIVATE_CDN_CLOUDFRONT_CANONICAL_ID
+                'GrantFullControl': 'id=%s' % config.PRIVATE_CDN_CLOUDFRONT_CANONICAL_ID,
+                'ContentType': content_type
             })
         else:
             raise InvalidS3Bucket("Attempted to upload to unknown S3 bucket.")


### PR DESCRIPTION
add Content-Type (e.g. `application/json`) to improve compression and caching