### PR TITLE
Find more favicons

### DIFF
--- a/update_favicon_urls.py
+++ b/update_favicon_urls.py
@@ -31,7 +31,13 @@ def get_favicon(domain: str) -> Tuple[str, str]:
             'User-Agent': USER_AGENT
         })
         soup = BeautifulSoup(response.text, features='lxml')
-        icon = soup.find('link', rel="shortcut icon")
+        icon = soup.find('link', rel="icon")
+
+        # Some sites may use an icon with a different rel.
+        if not icon:
+            icon = soup.find('link', rel="shortcut icon")
+        if not icon:
+            icon = soup.find('link', rel="apple-touch-icon")
 
         # Check if the icon exists, and the href is not empty. Surprisingly,
         # some sites actually do this (https://coinchoice.net/ + more).


### PR DESCRIPTION
This PR updates the default place we look for favicons and adds a few fallbacks, which should get us a few more icons.

**Note:** I can't seem to run the `image_sandbox` stuff (something to do with wasmer), so I temporarily disabled it all to get this to work, and that's why I haven't updated the local `favicons_lookup.json`.