### PR TITLE
Fix IGN's feed url in en_US

### DIFF
--- a/sources/sources.en_US.csv
+++ b/sources/sources.en_US.csv
@@ -19,7 +19,7 @@ https://www.bbc.com/,https://feeds.bbci.co.uk/news/rss.xml?edition=int,BBC World
 https://www.businessinsider.com/,https://feeds.businessinsider.com/custom/all,Business Insider,Business,Enabled,,,article,,markets.businessinsider.com;www.businessinsider.com,Business; Top Sources,17,https://feeds2.feedburner.com/businessinsider
 https://www.gamespot.com/,https://www.gamespot.com/feeds/news,Gamespot,Gaming,Enabled,,,article,,www.gamespot.com,Gaming; Top Sources,18,
 https://www.mayoclinic.org/,https://www.mayoclinic.org/rss/all-health-information-topics,Mayo Clinic,Health,Enabled,,,article,,www.mayoclinic.org,Health; Top Sources,19,
-https://www.ign.com/,http://feeds.ign.com/ign/reviews,IGN Reviews,Gaming,Enabled,,,article,,www.ign.com,Gaming; Top Sources,20,
+https://www.ign.com/,https://feeds.ign.com/ign/reviews,IGN Reviews,Gaming,Enabled,,,article,,www.ign.com,Gaming; Top Sources,20,
 https://screenrant.com/,https://screenrant.com/feed/,Screenrant,Film and TV,Enabled,,,article,,screenrant.com,Film and TV; Top Sources,21,
 https://www.usatoday.com/,https://rssfeeds.usatoday.com/usatoday-newstopstories&x=1,USA Today,US News,Enabled,,,article,,usatoday.com,US News,22,
 https://www.cbssports.com/,https://www.cbssports.com/rss/headlines/,CBSSports,Sports,Enabled,,,article,,www.cbssports.com,Sports; Top Sources,23,


### PR DESCRIPTION
In other locales, the feed urls start with https:// scheme.  This seems to cause duplicated IGN to be revealed

Possibly fix https://github.com/brave/brave-browser/issues/28400