### PR TITLE
[DRAFT] Add domain override functionality for background colors and cover images

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ To update the favicon urls:
     export PYTHONPATH=$PWD:$PWD/src
     NO_UPLOAD=1 NO_DOWNLOAD=1 python src/favicons_covers/update_favicon_urls.py
 
+To manage domain overrides for background colors and cover urls:
+
+    export PYTHONPATH=$PWD:$PWD/src
+    python bin/manage.py add domain_override [domain] [background_color|cover_url] [value]
+
 ### Committing code
 
 We configured the pre-commit hooks to ensure the quality of the code. To setup the pre-commit hooks run the following

--- a/bin/manage.py
+++ b/bin/manage.py
@@ -2,8 +2,9 @@ import argparse
 import psycopg2
 from config import get_config
 
-## this script can be called in the following ways:
-## python manage.py add domain_override domain type value
+#  python ./bin/manage.py add domain_override domain type value
+#    or
+#  python ./bin/manage.py remove domain_override domain type
 
 def manage_domain_overrides(operation, domain, type, value):
     assert(operation in ['add', 'remove'])
@@ -46,5 +47,3 @@ if __name__ == "__main__":
       manage_domain_overrides(args.operation, args.domain, args.type, args.value)
     else:
       print("Invalid parameter. Only 'domain_override' is supported.")
-
-

--- a/bin/manage.py
+++ b/bin/manage.py
@@ -1,0 +1,50 @@
+import argparse
+import psycopg2
+from config import get_config
+
+## this script can be called in the following ways:
+## python manage.py add domain_override domain type value
+
+def manage_domain_overrides(operation, domain, type, value):
+    assert(operation in ['add', 'remove'])
+    assert(type in ['background_color', 'cover_url'])
+
+    # if the type is background_color, the value must be a valid hex color code
+    if type == 'background_color':
+        assert(value[0] == '#')
+        assert(len(value) == 7)
+        assert(all(c in '0123456789abcdef' for c in value[1:]))
+
+    # if the type is cover_url, the value must be a url
+    if type == 'cover_url':
+        assert(value[:4] == 'http')
+
+    config = get_config()
+    conn = psycopg2.connect(dbname=config.db_name, host=config.db_host)
+    cur = conn.cursor()
+
+    if operation == 'add':
+        cur.execute("INSERT INTO domain_overrides (domain, type, value) VALUES (%s, %s, %s) on conflict (domain, type) do update set value = %s, updated_at = current_timestamp", (domain, type, value, value))
+    elif operation == 'remove':
+        cur.execute("DELETE FROM domain_overrides WHERE domain = %s AND type = %s", (domain, type))
+
+    conn.commit()
+    cur.close()
+    conn.close()
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Manage domain overrides.')
+    parser.add_argument('operation', choices=['add', 'remove'], help='The operation to perform.')
+    parser.add_argument('parameter', choices=['domain_override'], help='The parameter to which the operation applies.')
+    parser.add_argument('domain', help='The domain to which the operation applies.')
+    parser.add_argument('type', help='The type to which the operation applies.')
+    parser.add_argument('value', nargs='?', help='The value to set for the type. Only required for "add" operation.')
+
+    args = parser.parse_args()
+
+    if args.parameter == 'domain_override':
+      manage_domain_overrides(args.operation, args.domain, args.type, args.value)
+    else:
+      print("Invalid parameter. Only 'domain_override' is supported.")
+
+

--- a/config.py
+++ b/config.py
@@ -41,6 +41,13 @@ class Configuration(BaseSettings):
     no_upload: Optional[str] = None
     no_download: Optional[str] = None
 
+    # Database configuration
+    db_host: str = "localhost"
+    db_name: str = "news"
+
+    # enabled domain overrides for background colors and cover images
+    domain_overrides: Optional[str] = None
+
     pcdn_url_base: str = Field(default="https://pcdn.brave.software")
 
     # Canonical ID of the private S3 bucket
@@ -64,6 +71,7 @@ class Configuration(BaseSettings):
     sentry_url: str = ""
 
     log_level: str = "info"
+
 
     structlog.configure(
         wrapper_class=structlog.make_filtering_bound_logger(

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -4,6 +4,7 @@ black==23.9.1
 bpython==0.24
 flake8==6.1.0
 isort==5.12.0
+psycopg2-binary==2.9.9
 pip-check-reqs==2.5.3
 pre-commit==3.4.0
 pylint==3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ html2text==2020.1.16
 metadata-parser==0.12.0
 orjson==3.9.7
 Pillow==10.0.1
+psycopg2-binary==2.9.9
 prometheus_client==0.17.1
 pydantic==1.10.13
 pytz==2023.3.post1

--- a/src/migrations/0001-initial.sql
+++ b/src/migrations/0001-initial.sql
@@ -1,0 +1,17 @@
+create table domain_override_types (
+  type text not null primary key
+);
+
+insert into domain_override_types (type) values
+  ('background_color'),
+  ('cover_url')
+;
+
+create table domain_overrides (
+  domain     text      not null,
+  type       text      not null references domain_override_types (type),
+  value      text      not null,
+  created_at timestamp not null default current_timestamp,
+  updated_at timestamp not null default current_timestamp,
+  primary key(domain, type)
+);

--- a/src/utils.py
+++ b/src/utils.py
@@ -183,3 +183,18 @@ def push_metrics_to_pushgateway(metric, metric_value, label_value, registry):
 
     except Exception as e:
         logger.error(f"Failed to push metrics: {e}")
+
+
+def perform_overrides(result, domain_overrides):
+    logger.info("replacing cover image and background color for domains in the domain_overrides table")
+    for override in domain_overrides:
+        # check to see if the domain is in the result
+        if result.get(override[0]):
+            if override[1] == "background_color":
+                logger.info(f"replacing background color for {override[0]}")
+                result[override[0]]["background_color"] = override[2]
+            elif override[1] == "cover_url":
+                logger.info(f"replacing cover url for {override[0]}")
+                result[override[0]]["cover_url"] = override[2]
+
+    return result

--- a/tests/test.py
+++ b/tests/test.py
@@ -12,7 +12,10 @@ from config import get_config
 from feed_processor_multi import score_entries, scrub_html
 from src import feed_processor_multi
 
+from utils import perform_overrides
+
 config = get_config()
+
 
 
 def test_feed_processor_download():
@@ -124,3 +127,16 @@ def test_score_entries():
     filtered_entries = score_entries(filtered_entries)
 
     assert filtered_entries
+
+def test_domain_overrides():
+    overrides = [
+        ['http://brave.com', 'background_color', '#000000'],
+        ['http://brave.com', 'cover_url', 'https://brave.com/cover.jpg'],
+        ['http://foo.com', 'cover_url', 'https://foo.com/cover2.jpg'] # this should be ignored
+    ]
+    result = { "http://brave.com": {"cover_url": "", "background_color": "#ffffff"} }
+
+    result = perform_overrides(result, overrides)
+
+    assert(result['http://brave.com']['background_color'] == '#000000')
+    assert(result['http://brave.com']['cover_url'] == 'https://brave.com/cover.jpg')


### PR DESCRIPTION
This commit introduces the ability to override the background color and cover image URL for specific domains. This is achieved through the addition of a new `domain_overrides` table in a new database and corresponding management scripts. The `perform_overrides` function has been added to apply these overrides when processing cover images. The necessary database configuration has been added to the `config.py` file. The `psycopg2-binary` package has been added to the requirements to handle PostgreSQL database interactions. Unit tests have been updated to cover the new functionality.