### PR TITLE
Setting up the pop_score normalization

### DIFF
--- a/config.py
+++ b/config.py
@@ -83,6 +83,9 @@ class Configuration(BaseSettings):
     )
 
     bs_pop_endpoint: str = ""
+    pop_score_cutoff = 300
+    pop_score_exponent = 2 / 3
+    pop_score_range = 300
 
     nu_api_url: str = ""
     nu_api_token: str = ""

--- a/config.py
+++ b/config.py
@@ -85,7 +85,7 @@ class Configuration(BaseSettings):
     bs_pop_endpoint: str = ""
     pop_score_cutoff = 300
     pop_score_exponent = 2 / 3
-    pop_score_range = 300
+    pop_score_range = 100
 
     nu_api_url: str = ""
     nu_api_token: str = ""

--- a/src/csv_to_json.py
+++ b/src/csv_to_json.py
@@ -44,6 +44,7 @@ feed_include_keys = {
     "max_entries": True,
     "og_images": True,
     "creative_instance_id": True,
+    "channels": True,
     "feed_url": True,
     "site_url": True,
     "destination_domains": True,

--- a/tests/test_feed_processor_multi.py
+++ b/tests/test_feed_processor_multi.py
@@ -284,7 +284,7 @@ class TestGetPopularityScore:
         result = get_popularity_score(out_article)
 
         # Assert that the popularity score is None
-        assert result["pop_score"] is None
+        assert result["pop_score"] == 1.0
 
 
 class TestGetPredictedCategory:


### PR DESCRIPTION
Current Output of the article:
```
[
      {
        "title": "In Mexico, Surveillance Orders That Read Like a Political Power List",
        "publish_time": "2023-11-09 19:35:21",
        "img": "https://static01.nyt.com/images/2023/09/27/multimedia/00-mexico-spying-jhqc/00-mexico-spying-jhqc-mediumSquareAt3X.jpg",
        "category": "Top News",
        "description": "The Mexico City attorney general’s office ordered the phone records of politicians and officials, court filings show. Many of the people targeted say they were singled out for political reasons.",
        "content_type": "article",
        "publisher_id": "9dfe110b0027d7bcbab5be6f42f4512172747474b293449ea25eb5239885c7a2",
        "publisher_name": "The New York Times",
        "creative_instance_id": "",
        "url": "https://www.nytimes.com/2023/11/09/world/americas/mexico-surveillance-attorney-general.html",
        "url_hash": "77b090337fd0a489e8ce5a94829a9fd79d674b177aa47c60e7c8d4205973ae36",
        "pop_score":
        {
            "org_pop_score": 10.9325564,
            "Top Sources": 20.296103947249595,
            "Top News": 20.296103947249595,
            "US News": 20.296103947249595
        },
        "predicted_category": null,
        "padded_img": "https://static01.nyt.com/images/2023/09/27/multimedia/00-mexico-spying-jhqc/00-mexico-spying-jhqc-mediumSquareAt3X.jpg",
        "score": 9440.59866639379
    },
    {
        "title": "Japan volcano: Plumes of smoke as new island emerges after eruption",
        "publish_time": "2023-11-09 19:29:52",
        "img": "https://ichef.bbci.co.uk/news/1024/branded_news/BBAE/production/_131664084_p0grs3bd.jpg",
        "category": "World News",
        "description": "The island has already shrunk slightly as waves hit the \"crumbly\" formation.",
        "content_type": "article",
        "publisher_id": "60bef5cb5f18a08ea4ba2311dd5d73cfa4546f8166016e62573e84351beb5f41",
        "publisher_name": "BBC World News",
        "creative_instance_id": "",
        "url": "https://www.bbc.co.uk/news/av/world-asia-67374295",
        "url_hash": "15e0ab71aa5c77211768428335b035c734e1250411db927ca78bac8dd423eef8",
        "pop_score":
        {
            "org_pop_score": 28.8923241,
            "World News": 300.0,
            "Top Sources": 53.63810546737491
        },
        "predicted_category": null,
        "padded_img": "https://ichef.bbci.co.uk/news/1024/branded_news/BBAE/production/_131664084_p0grs3bd.jpg",
        "score": 148.02272005569887
    }
]
```

- org_pop_score: Show what we get from BS API (after applying https://github.com/brave/news-aggregator/issues/611#issuecomment-1786005298 formula)
- Other fields are the channel wise `pop_score`

If you see `pop_score` in the second example, I personally think channel wise average is not good solution.
What do you suggest? 
cc: @LorenzoMinto @aekeus @fallaciousreasoning ki