### PR TITLE
Article categorization pipeline

### DIFF
--- a/config.py
+++ b/config.py
@@ -89,6 +89,8 @@ class Configuration(BaseSettings):
 
     nu_api_url: str = ""
     nu_api_token: str = ""
+    nu_default_channels = ["Funny"]
+    nu_augment_channels = ["Culture", "Top News", "World News"]
 
     @validator("img_cache_path")
     def create_img_cache_path(cls, v: Path) -> Path:

--- a/config.py
+++ b/config.py
@@ -90,7 +90,13 @@ class Configuration(BaseSettings):
     nu_api_url: str = ""
     nu_api_token: str = ""
     nu_default_channels = ["Funny"]
-    nu_augment_channels = ["Culture", "Top News", "World News"]
+    nu_augment_channels = [
+        "Top Sources",
+        "Top News",
+        "World News",
+        "US News",
+        "Culture",
+    ]
     nu_confidence_threshold = 0.8
     nu_excluded_channels = ["Crime"]
 

--- a/config.py
+++ b/config.py
@@ -89,8 +89,9 @@ class Configuration(BaseSettings):
 
     nu_api_url: str = ""
     nu_api_token: str = ""
-    nu_default_channels = ["Funny"]
+    nu_default_channels = ["Funny", "Crime"]
     nu_augment_channels = ["Culture", "Top News", "World News"]
+    category_fallback_confidence_threshold = .8
 
     @validator("img_cache_path")
     def create_img_cache_path(cls, v: Path) -> Path:

--- a/config.py
+++ b/config.py
@@ -34,8 +34,8 @@ class Configuration(BaseSettings):
     img_cache_path: Path = Field(default=Path(__file__).parent / "output/feed/cache")
 
     # Set the number of processes to spawn for all multiprocessing tasks.
-    concurrency = cpu_count()
-    thread_pool_size = cpu_count() * 10
+    concurrency: int = cpu_count() - 1
+    thread_pool_size: int = cpu_count() * 5
 
     # Disable uploads and downloads to S3. Useful when running locally or in CI.
     no_upload: Optional[str] = None
@@ -89,9 +89,10 @@ class Configuration(BaseSettings):
 
     nu_api_url: str = ""
     nu_api_token: str = ""
-    nu_default_channels = ["Funny", "Crime"]
+    nu_default_channels = ["Funny"]
     nu_augment_channels = ["Culture", "Top News", "World News"]
-    category_fallback_confidence_threshold = .8
+    nu_confidence_threshold = 0.8
+    nu_excluded_channels = ["Crime"]
 
     @validator("img_cache_path")
     def create_img_cache_path(cls, v: Path) -> Path:


### PR DESCRIPTION
Resolves https://github.com/brave/news-aggregator/issues/612
Spec: https://docs.google.com/document/d/1cZOS2D74jcA5svOrHXOuxhQqdQpHTXMCZYAj_GkQAw0/edit

- [x] Default/Augmented channels logic
- [x] Sufficient description length 
- [x] Sufficient classification confidence
- [x] Certain categories should not be treated as channels

Categories not to be treated as channels: **Crime**
In the future, these categories might be used for brand safety purposes, for now let's disregard and fallback to the publisher category