### PR TITLE
Fix brave blog feed and images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ pytest:
 
 validjson:
 	export PYTHONPATH=$PWD:$PWD/src
-	mv sources/sources.csv sources/sources-orig.csv ; head -10 sources/sources-orig.csv > sources/sources.csv
+	mv sources/sources.csv sources/sources-orig.csv ; head -5 sources/sources-orig.csv > sources/sources.csv
 	echo Checking that csv_to_json.py creates valid JSON files...
 	NO_UPLOAD=1 NO_DOWNLOAD=1 python src/csv_to_json.py
 	mv sources/sources-orig.csv sources/sources.csv

--- a/src/feed_processor_multi.py
+++ b/src/feed_processor_multi.py
@@ -363,7 +363,7 @@ def process_articles(article, _publisher):  # noqa: C901
     image_url = get_article_img(article)
 
     parsed_url = urlparse(image_url)
-    if not parsed_url.netloc:
+    if not parsed_url.netloc and image_url:
         # If not, update the URL by joining it with the publisher's URL
         image_url = urljoin(_publisher["site_url"], image_url)
 

--- a/src/feed_processor_multi.py
+++ b/src/feed_processor_multi.py
@@ -298,6 +298,8 @@ def get_article_img(article: Dict) -> str:  # noqa: C901
         if image_url:
             return image_url
 
+    return image_url
+
 
 def process_articles(article, _publisher):  # noqa: C901
     """

--- a/src/feed_processor_multi.py
+++ b/src/feed_processor_multi.py
@@ -268,8 +268,8 @@ def get_article_img(article: Dict) -> str:  # noqa: C901
         if image_url:
             return image_url
 
-    if "media_content" in article or "media_thumbnail" in article:
-        media = article.get("media_content") or article.get("media_thumbnail")
+    if "media_content" in article:
+        media = article.get("media_content")
         content_with_max_width = max(
             media, key=lambda content: int(content.get("width") or 0), default=None
         )

--- a/src/image_processor_sandboxed.py
+++ b/src/image_processor_sandboxed.py
@@ -101,20 +101,24 @@ def get_image_with_max_size(item, max_bytes=1000000):
         tuple: A tuple containing the content of the response as bytes and a boolean indicating if the content
         is larger than the maximum size.
     """
-    is_large = False
-    response = requests.get(
-        item.get("img"),
-        timeout=config.request_timeout,
-        headers={"User-Agent": ua.random, **config.default_headers},
-    )
-    response.raise_for_status()
-    if (
-        response.headers.get("Content-Length")
-        and int(response.headers.get("Content-Length")) > max_bytes
-    ):
-        is_large = True
+    try:
+        is_large = False
+        response = requests.get(
+            item.get("img"),
+            timeout=config.request_timeout,
+            headers={"User-Agent": ua.random, **config.default_headers},
+        )
+        response.raise_for_status()
+        if (
+            response.headers.get("Content-Length")
+            and int(response.headers.get("Content-Length")) > max_bytes
+        ):
+            is_large = True
 
-    return item, response.content, is_large
+        return item, response.content, is_large
+    except Exception as e:
+        logger.info(f"Error retrieving image from URL {item.get('url')}: {e}")
+        return item, None, False
 
 
 class ImageProcessor:
@@ -124,8 +128,8 @@ class ImageProcessor:
         s3_path="brave-today/cache/{}",
         force_upload=False,
         img_format="jpg",
-        img_width=900,
-        img_height=750,
+        img_width=700,
+        img_height=500,
         img_size=1000000,
     ):
         self.s3_bucket = s3_bucket

--- a/tests/test_feed_processor_multi.py
+++ b/tests/test_feed_processor_multi.py
@@ -98,7 +98,6 @@ class TestProcessImage:
         out_item = process_image(item)
         assert out_item["img"] is not None
         assert out_item["padded_img"] is not None
-        assert out_item["padded_img"].endswith(".pad")
 
     # item has 'img' key but its value is None
     def test_item_img_value_is_none(self):

--- a/tests/test_feed_processor_multi.py
+++ b/tests/test_feed_processor_multi.py
@@ -86,21 +86,24 @@ class TestParseRss:
 class TestProcessImage:
     # item has 'img' key
     def test_item_has_img_key(self):
-        item = {
-            "img": "https://www.usmagazine.com/wp-content/uploads/2023/10/Ed-Sheeran-s-Reason-for-"
-            "Building-His-Final-Resting-Place-in-His-Own-Backyard-Will-Gut-You-297."
-            "jpg?crop=0px%2C86px%2C1331px%2C700px&resize=1200%2C630&quality=86&strip=all"
-        }
-        process_image(item)
-        assert item["img"] is not None
-        assert item["padded_img"] is not None
+        item = (
+            {
+                "img": "https://www.usmagazine.com/wp-content/uploads/2023/10/Ed-Sheeran-s-Reason-for-"
+                "Building-His-Final-Resting-Place-in-His-Own-Backyard-Will-Gut-You-297."
+                "jpg?crop=0px%2C86px%2C1331px%2C700px&resize=1200%2C630&quality=86&strip=all"
+            },
+            b"",
+        )
+        out_item = process_image(item)
+        assert out_item["img"] is not None
+        assert out_item["padded_img"] is not None
 
     # item has 'img' key but its value is None
     def test_item_img_value_is_none(self):
-        item = {"img": None}
-        process_image(item)
-        assert item["img"] == ""
-        assert item["padded_img"] == ""
+        item = ({"img": None}, None)
+        out_item = process_image(item)
+        assert out_item["img"] == ""
+        assert out_item["padded_img"] == ""
 
 
 class TestProcessArticles:

--- a/tests/test_feed_processor_multi.py
+++ b/tests/test_feed_processor_multi.py
@@ -129,6 +129,7 @@ class TestProcessArticles:
             "category": "example_category",
             "content_type": "text",
             "channels": ["Top News"],
+            "site_url": "https://brave.com/",
         }
 
         processed_article = process_articles(article, _publisher)

--- a/tests/test_feed_processor_multi.py
+++ b/tests/test_feed_processor_multi.py
@@ -3,6 +3,7 @@ from datetime import datetime
 
 import pytest
 import pytz
+import requests
 from requests import HTTPError
 
 from config import get_config
@@ -86,17 +87,18 @@ class TestParseRss:
 class TestProcessImage:
     # item has 'img' key
     def test_item_has_img_key(self):
+        img_url = (
+            "https://www.learningcontainer.com/wp-content/uploads/2020/08/"
+            "Sample-Small-Image-PNG-file-Download.png"
+        )
         item = (
-            {
-                "img": "https://www.usmagazine.com/wp-content/uploads/2023/10/Ed-Sheeran-s-Reason-for-"
-                "Building-His-Final-Resting-Place-in-His-Own-Backyard-Will-Gut-You-297."
-                "jpg?crop=0px%2C86px%2C1331px%2C700px&resize=1200%2C630&quality=86&strip=all"
-            },
-            b"",
+            {"img": img_url},
+            requests.get(img_url).content,
         )
         out_item = process_image(item)
         assert out_item["img"] is not None
         assert out_item["padded_img"] is not None
+        assert out_item["padded_img"].endswith(".pad")
 
     # item has 'img' key but its value is None
     def test_item_img_value_is_none(self):


### PR DESCRIPTION
Description:
- Publisher in which images are placed in content tag like Brave.
- Optimized the cache_images wrt to memory. By dividing the large function into 2 parts (I/O part (threading) and CPU heavy part (multiprocessing))
- Updated the image resized resolution which is really needed for client, to save the RAM at runtime.
- Remove the thumbnail tag to get the image of the article which always gives low resolution images.
- If the URL is not complete, join it with publisher URL.

Things not fixed:
- 403/443 error while getting all the images from articles URL.
- Payment wall while getting images from article URL, i.e. New York Times.


Resolves: https://github.com/brave/news-aggregator/issues/705
Resolves: https://github.com/brave/news-aggregator/issues/682